### PR TITLE
make Static function

### DIFF
--- a/src/o2.js
+++ b/src/o2.js
@@ -187,3 +187,23 @@ O2.mixin = function(pPrototype, pMixin) {
 	pPrototype.extendPrototype(pMixin);
 };
 
+/**
+ * Make method static
+ * @param object obj
+ * @param array staticMethods static methods list
+ * @return this
+ */
+O2.makeStatic = function(obj, staticMethods) {
+    var myObject = obj.prototype;
+    if(typeof myObject != "object") {
+        console.log("O2 error", "typeof object for makestatic != 'object'");
+    } else {
+        staticMethods.forEach(function(row) {
+            if(row in myObject) {
+                obj[row] = myObject[row];
+            } 
+        });
+    }
+    return this;
+}
+

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -67,6 +67,21 @@ QUnit.test('Inheritance', function(assert) {
 	TEST = {};
 });
 
+/**
+ * test O2.makeStatic()..
+ */
+QUnit.test('MakeStatic', function(assert) {
+    O2.createClass('TEST.Class1', {
+        staticMethod: function() {
+            return true;
+        }
+    });
+    O2.makeStatic(TEST.Class1, ["staticMethod"]);
+    assert.equal(('staticMethod' in TEST.Class1), true, 'method cloned from prototype');
+    assert.equal(TEST.Class1.staticMethod(), true, 'static method is now callable');
+    TEST = {};
+});
+
 
 /*
  #    #     #    #    #     #    #    #


### PR DESCRIPTION
an additionnal method to render static function
simplify call static function with:
"NameClass.staticFunction()" shorter than "NameClass.prototype.staticFunction()"
it give no additional tool, but it's more intuitive
...at least for me
